### PR TITLE
feat(nvim): remove redundant installation of fzf

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -9,7 +9,7 @@ Plug 'morhetz/gruvbox'
 Plug 'tpope/vim-surround'
 
 " fzf
-Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' } 
+Plug 'junegunn/fzf'
 Plug 'junegunn/fzf.vim'
 
 " vim airline


### PR DESCRIPTION
Reference: https://github.com/junegunn/fzf/blob/master/README-VIM.md

if we just use `Plug 'junegunn/fzf'`,
> The Vim plugin will pick up fzf binary available on the system.

Also, it's not good to have fzf installed in homedir since we are migrating to XDG Base Dir.

Tested with my MacOS & Ubuntu 20.04 on WSL2.