### PR TITLE
feat(misc): update delta commands for delta release 0.3.0

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -29,3 +29,9 @@
 [alias]
     parent = "! git log --pretty=format:'%D' HEAD^ | grep 'origin/' | head -n1 | sed 's@origin/@@' | sed 's@,.*@@'"
     lg = log --graph --pretty=format:'%Cred%h%Creset - %s %Cgreen(%cr) %C(bold blue)<%an>%Creset %C(yellow)%d%Creset' --abbrev-commit
+
+[delta]
+    number = true
+    side-by-side = true
+    syntax-theme = TwoDark
+    zero-style = dim syntax

--- a/.config/zsh/functions.zsh
+++ b/.config/zsh/functions.zsh
@@ -6,10 +6,3 @@
 function da() {
   git --git-dir=$HOME/.dotfiles/ --work-tree=$HOME add $@
 }
-
-# Component: diff
-# Purpose: use delta as diff
-# Reference: https://github.com/dandavison/delta/pull/56
-function dt() {
-  diff -u $@ | delta --theme="Dracula"
-}


### PR DESCRIPTION
As `delta` release 0.3.0 came out, we can now:
* Enable `side-by-side`diff view in git diff
* Use `delta minus_file plus_file` as a replacement of `diff minus_file plus_file` straightforwardly