### PR TITLE
fix(nvim): use new nerdtree git plugin config

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -168,7 +168,7 @@ let g:NERDTreeDirArrowExpandable = ''
 let g:NERDTreeDirArrowCollapsible = ''
 
 " *************Nerd Tree git*************
-let g:NERDTreeIndicatorMapCustom = {
+let g:NERDTreeGitStatusIndicatorMapCustom = {
 \       'Modified' : '✹',
 \       'Staged'   : '✚',
 \       'Untracked': '✭',


### PR DESCRIPTION
`g:NERDTreeIndicatorMapCustom` is deprecated, please apply this PR after executing `:PlugUpdate` in neovim.

Reference: https://github.com/Xuyuanp/nerdtree-git-plugin/pull/60