### PR TITLE
feat(nvim): auto install plugins & change installation path

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -1,7 +1,17 @@
 filetype off 
 
 " ##################################Install Plugin##################################
-call plug#begin('~/.config/nvim/plugged')
+" Bootstrap Plug
+let autoload_plug_path = stdpath('data') . '/site/autoload/plug.vim'
+if !filereadable(autoload_plug_path)
+  silent execute '!curl -fLo ' . autoload_plug_path . ' --create-dirs 
+    \ "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"'
+  autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
+endif
+unlet autoload_plug_path
+
+let pluginsPath = stdpath('data') . '/plugged'
+call plug#begin(pluginsPath)
 
 Plug 'mhinz/vim-startify'
 Plug 'morhetz/gruvbox'
@@ -51,6 +61,7 @@ Plug 'multilobyte/gtags-cscope'
 Plug 'sheerun/vim-polyglot'
 
 call plug#end()
+unlet pluginsPath
 
 " ##################################ShortCut setting##################################
 " ************switch between tabs************

--- a/scripts/provisioning/create-xdg-dir.sh
+++ b/scripts/provisioning/create-xdg-dir.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p "$XDG_CONFIG_HOME/{asdf,aws,bat,docker,k9s,nvim,zsh}"
-mkdir -p "$XDG_DATA_HOME/{asdf,docker-machine,go,node,zinit,zlua,zsh}"
+mkdir -p "$XDG_DATA_HOME/{asdf,docker-machine,go,node,nvim,zinit,zlua,zsh}"
 mkdir -p "$XDG_CACHE_HOME/zcompdump"


### PR DESCRIPTION
1. add auto installation script that we don't need to manual install all plugins on first time installation.
2. change plugins installation path from `~/.config/nvim/plugged` to `~/.local/share/nvim/plugged`, which make more sense because the category is `data` not `config`.

**You can safely delete `~/.config/nvim/plugged` then reopen Neovim after applying this PR.**

References:
1. [Auto installation for Neovim] https://github.com/junegunn/vim-plug/issues/739
2. [Use XDG_DATA_DIR as plugins installation path](https://github.com/junegunn/vim-plug/tree/13ea184015c30be5160ae285aedc0eaec0c72e6c#example): `For Neovim: stdpath('data') . '/plugged'`
