### PR TITLE
fix(zinit): fix exa completion url

### DIFF
--- a/.config/zsh/zinit.zsh
+++ b/.config/zsh/zinit.zsh
@@ -46,7 +46,7 @@ zinit light sharkdp/bat
 zinit ice from"gh-r" as"program" mv"exa* -> exa"
 zinit light ogham/exa
 zinit ice as"completion" mv"c* -> _exa"
-zinit snippet "https://github.com/ogham/exa/blob/master/contrib/completions.zsh"
+zinit snippet "https://github.com/ogham/exa/blob/master/completions/completions.zsh"
 
 # jq
 zinit ice from"gh-r" as"program" mv"jq* -> jq"


### PR DESCRIPTION
Please restart a new terminal session & do `zinit delete --clean` after applying the PR.